### PR TITLE
Add method to skip zabbix-agent installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Install Method options are:
     node['zabbix']['agent']['install_method'] = 'cookbook_file' # not yet implemented
     node['zabbix']['agent']['install_method'] = 'chocolatey' # Default for Windows
 
+    # skip is preferred if no internet access when provisioning
+    # zabbix agent was already installed via chef during image bake process
+    node['zabbix']['agent']['install_method'] = 'skip'
+
 Version
 
     node['zabbix']['agent']['version'] # Default 2.4.4 (set to 2.4.1 for latest prebuild)

--- a/recipes/install_skip.rb
+++ b/recipes/install_skip.rb
@@ -1,0 +1,9 @@
+# Author:: Philip Oliva (<philoliva8@gmail.com>)
+# Cookbook Name:: zabbix-agent
+# Recipe:: install_skip
+#
+# Apache 2.0
+
+log 'Skip the installation of zabbix agent' do
+  level :info
+end


### PR DESCRIPTION
Skip is preferred if no internet access when provisioning and zabbix agent was already installed via chef during image bake process.

Solves Issue #10 