### PR TITLE
Fix for warning about method access to node attributes being deprecated

### DIFF
--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -42,7 +42,7 @@ else
     end
   end
   package 'zabbix-agent' do
-    if node.platform_family == 'debian'
+    if node['platform_family'] == 'debian'
       options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
     end
     action :upgrade


### PR DESCRIPTION
Fix for warning about method access to node attributes being deprecated and removed in Chef 13