### PR TITLE
Remove supports property to allow compatibility with Chef 13

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,7 +22,7 @@ else
     uid node['zabbix']['agent']['uid'] if node['zabbix']['agent']['uid']
     gid node['zabbix']['agent']['gid'] || node['zabbix']['agent']['group']
     system true
-    supports manage_home: true
+    manage_home true
   end
 end
 


### PR DESCRIPTION
As the supports property was removed in Chef 13, the cookbook fails to converge on such installations. 