### PR TITLE
replaced resource chocolatey with chocolatey_package for chef-client …

### DIFF
--- a/.foodcritic
+++ b/.foodcritic
@@ -1,0 +1,1 @@
+~license

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ namespace :style do
       FoodCritic::Rake::LintTask.new(:chef) do |t|
         puts 'Running Foodcritic...'
         t.options = {
-          fail_tags: ['any']
+          fail_tags: ['any'],
         }
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ namespace :style do
       FoodCritic::Rake::LintTask.new(:chef) do |t|
         puts 'Running Foodcritic...'
         t.options = {
-          fail_tags: ['any'],
+          fail_tags: ['any']
         }
       end
     end
@@ -104,7 +104,7 @@ desc 'Run all unit tests'
 task unit: ['unit:rspec']
 
 desc 'Run style and unit tests for light CI'
-task travis: %w(berkshelf style unit)
+task travis: %w[berkshelf style unit]
 
 desc 'Run all tests including test Kitchen with Vagrant'
 task default: ['unit', 'style', 'integration:vagrant']

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,9 @@ version '0.14.1'
 
 chef_version '>= 12.7.0' if respond_to?(:chef_version)
 
+issues_url 'https://github.com/TD-4242/zabbix-agent/issues'
+source_url 'https://github.com/TD-4242/zabbix-agent'
+
 # tested on ubuntu 10.04 12.04 and 14.04
 supports 'ubuntu', '>= 10.04'
 # tested on centos 6.6 and 7.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,9 @@ description 'Installs/Configures Zabbix Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/TD-4242/zabbix-agent'
 issues_url 'https://github.com/TD-4242/zabbix-agent/issues'
-version '0.14.0'
+version '0.14.1'
+
+chef_version '>= 12.7.0' if respond_to?(:chef_version)
 
 # tested on ubuntu 10.04 12.04 and 14.04
 supports 'ubuntu', '>= 10.04'

--- a/recipes/agent_registration.rb
+++ b/recipes/agent_registration.rb
@@ -8,7 +8,7 @@
 connection_info = {
   url: "http://#{zabbix_server['zabbix']['web']['fqdn']}/api_jsonrpc.php",
   user: zabbix_server['zabbix']['web']['login'],
-  password: zabbix_server['zabbix']['web']['password'],
+  password: zabbix_server['zabbix']['web']['password']
 }
 
 ip_address = node['ipaddress']
@@ -29,7 +29,7 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['zabbix_agent_port'],
+    port: node['zabbix']['agent']['zabbix_agent_port']
   },
   jmx: {
     type: 4,
@@ -37,7 +37,7 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['jmx_port'],
+    port: node['zabbix']['agent']['jmx_port']
   },
   snmp: {
     type: 2,
@@ -45,8 +45,8 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['snmp_port'],
-  },
+    port: node['zabbix']['agent']['snmp_port']
+  }
 }
 
 interface_list = node['zabbix']['agent']['interfaces']

--- a/recipes/agent_registration.rb
+++ b/recipes/agent_registration.rb
@@ -8,7 +8,7 @@
 connection_info = {
   url: "http://#{zabbix_server['zabbix']['web']['fqdn']}/api_jsonrpc.php",
   user: zabbix_server['zabbix']['web']['login'],
-  password: zabbix_server['zabbix']['web']['password']
+  password: zabbix_server['zabbix']['web']['password'],
 }
 
 ip_address = node['ipaddress']
@@ -29,7 +29,7 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['zabbix_agent_port']
+    port: node['zabbix']['agent']['zabbix_agent_port'],
   },
   jmx: {
     type: 4,
@@ -37,7 +37,7 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['jmx_port']
+    port: node['zabbix']['agent']['jmx_port'],
   },
   snmp: {
     type: 2,
@@ -45,8 +45,8 @@ interface_definitions = {
     useip: 1,
     ip: ip_address,
     dns: node['fqdn'],
-    port: node['zabbix']['agent']['snmp_port']
-  }
+    port: node['zabbix']['agent']['snmp_port'],
+  },
 }
 
 interface_list = node['zabbix']['agent']['interfaces']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -77,7 +77,7 @@ end
 
 # Define zabbix owned folders
 zabbix_dirs = [
-  node['zabbix']['log_dir'],
+  node['zabbix']['log_dir']
 ]
 zabbix_dirs << node['zabbix']['run_dir'] unless node['platform'] == 'windows'
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -27,7 +27,7 @@ else
 end
 
 directory node['zabbix']['install_dir'] do
-  unless node.platform_family?('windows') && node['zabbix']['agent']['user'] == 'Administrator'
+  unless platform_family?('windows') && node['zabbix']['agent']['user'] == 'Administrator'
     owner node['zabbix']['agent']['user']
     group node['zabbix']['agent']['group']
   end
@@ -77,14 +77,14 @@ end
 
 # Define zabbix owned folders
 zabbix_dirs = [
-  node['zabbix']['log_dir']
+  node['zabbix']['log_dir'],
 ]
 zabbix_dirs << node['zabbix']['run_dir'] unless node['platform'] == 'windows'
 
 # Create zabbix folders
 zabbix_dirs.each do |dir|
   directory dir do
-    unless node.platform_family?('windows') && node['zabbix']['agent']['user'] == 'Administrator'
+    unless platform_family?('windows') && node['zabbix']['agent']['user'] == 'Administrator'
       owner node['zabbix']['agent']['user']
       group node['zabbix']['agent']['group']
     end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -9,7 +9,7 @@
 
 if node['platform'] == 'windows'
   include_recipe 'chocolatey'
-  chocolatey 'zabbix-agent'
+  chocolatey_package 'zabbix-agent'
 else
   case node['platform']
   when 'ubuntu', 'debian'

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -10,14 +10,14 @@ case node['platform']
 when 'ubuntu', 'debian'
   include_recipe 'apt'
   # install some dependencies
-  %w(libcurl3 libcurl4-openssl-dev).each do |pck|
+  %w[libcurl3 libcurl4-openssl-dev].each do |pck|
     package pck do
       action :install
     end
   end
 
 when 'redhat', 'centos', 'scientific', 'amazon', 'fedora'
-  %w(curl-devel openssl-devel redhat-lsb).each do |pck|
+  %w[curl-devel openssl-devel redhat-lsb].each do |pck|
     package pck do
       action :install
     end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -23,7 +23,7 @@ when 'sysvinit'
   service 'zabbix-agent' do
     pattern 'zabbix_agentd'
     supports status: true, start: true, stop: true, restart: true
-    action [:enable, :start]
+    action %i[enable start]
   end
 when 'systemd'
   template '/etc/systemd/system/zabbix-agent.service' do
@@ -37,7 +37,7 @@ when 'systemd'
   service 'zabbix-agent' do
     pattern 'zabbix_agentd'
     supports status: true, start: true, stop: true, restart: true
-    action [:enable, :start]
+    action %i[enable start]
   end
   # when 'upstart'
   #   upstart.conf
@@ -53,6 +53,6 @@ else
   service 'zabbix-agent' do
     pattern 'zabbix_agentd'
     supports status: true, start: true, stop: true, restart: true
-    action [:enable, :start]
+    action %i[enable start]
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -122,7 +122,7 @@ describe 'zabbix-agent::default' do
       expect(chef_run).to add_apt_repository('zabbix').with(
         uri: 'http://repo.zabbix.com/zabbix/3.0/ubuntu/',
         components: ['main'],
-        key: 'http://repo.zabbix.com/zabbix-official-repo.key'
+        key: ['http://repo.zabbix.com/zabbix-official-repo.key']
       )
     end
 


### PR DESCRIPTION
resource `chocolatey` is deprecated, cookbook is failing on recent chef-client versions (on platform windows).

please note that this breaks compatibility with chef-clients < 12.7.0
